### PR TITLE
add localPlayerUrl setting to enable iframe codes to use localhost in…

### DIFF
--- a/client/html/layouts/application.html
+++ b/client/html/layouts/application.html
@@ -9,6 +9,10 @@
     <script type="text/javascript">
       window.DEFAULT_SETTINGS = {
         assessmentPlayerUrl: "https://d5lqgzoidv722.cloudfront.net",
+
+        // When localPlayerUrl is set, the generated iframe url will have the
+        // localPlayerUrl in place of the assessmentPlayerUrl.
+        localPlayerUrl: "",
         rootEndpoint: "https://4h8n6sg95j.execute-api.us-east-1.amazonaws.com/dev/"
       };
       window.DEFAULT_JWT = {};

--- a/client/js/components/home.jsx
+++ b/client/js/components/home.jsx
@@ -178,7 +178,11 @@ class Home extends React.Component {
     let assessOffered = this.props.assessment_offered;
     if(!_.isEmpty(assessOffered)){
       let qBankHost = this.props.settings.qBankHost ? this.props.settings.qBankHost : "https://qbank-clix-dev.mit.edu";
-      let playerHost = this.props.settings.assessmentPlayerUrl; //This will need to be the instance deployed, not localhost.
+      let hostedPlayer = this.props.settings.assessmentPlayerUrl;
+      let localPlayerUrl = this.props.settings.localPlayerUrl;
+
+      // localPlayerUrl should take precedence over the hosted player
+      let playerHost = localPlayerUrl ? localPlayerUrl : hostedPlayer;
       let url = `${playerHost}/?unlock_next=ON_CORRECT&api_url=${qBankHost}/api/v1&bank=${assessOffered.bankId}&assessment_offered_id=${assessOffered.id}#/assessment`;
       return `<iframe src="${url}"/>`;
     } else {

--- a/client/js/components/home.jsx
+++ b/client/js/components/home.jsx
@@ -182,8 +182,7 @@ class Home extends React.Component {
       let localPlayerUrl = this.props.settings.localPlayerUrl;
 
       // localPlayerUrl should take precedence over the hosted player
-      let playerHost = localPlayerUrl ? localPlayerUrl : hostedPlayer;
-      let url = `${playerHost}/?unlock_next=ON_CORRECT&api_url=${qBankHost}/api/v1&bank=${assessOffered.bankId}&assessment_offered_id=${assessOffered.id}#/assessment`;
+      let url = `${localPlayerUrl || hostedPlayer}/?unlock_next=ON_CORRECT&api_url=${qBankHost}/api/v1&bank=${assessOffered.bankId}&assessment_offered_id=${assessOffered.id}#/assessment`;
       return `<iframe src="${url}"/>`;
     } else {
       return "";


### PR DESCRIPTION
# Code-review checklist
- Documentation
  - [ ] Interfaces describe how other programmers would use them.
  - [ ] Code that is not obvious has documentation describing why
    that code is the way it is.

…stead of the hosted url

Adds localPlayerUrl setting that enables the player to output iframe codes with a local url instead of hosted player url . 
